### PR TITLE
Fixed output to colorize the loglevel and use simple non-json output for string messages.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 <!--## Unreleased-->
+
+* Fixed output to colorize the loglevel and use simple non-json output for string messages.
+
 <!--
   New PRs should document their changes here, uncommenting the Unreleased
   heading as necessary.

--- a/index.ts
+++ b/index.ts
@@ -34,7 +34,10 @@ export class PolymerLogger {
 
     this._transport = defaultConfig.transportFactory({
       level: options.level || 'info',
-      format: winston.format.prettyPrint(),
+      format: winston.format.combine(
+        winston.format.colorize(),
+        winston.format.simple()
+      ),
     });
 
     this._logger = winston.createLogger({transports: [this._transport]});

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,9 +17,10 @@
       "dev": true
     },
     "@types/node": {
-      "version": "10.7.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.7.1.tgz",
-      "integrity": "sha512-EGoI4ylB/lPOaqXqtzAyL8HcgOuCtH2hkEaLmkueOYufsTFWBn4VCvlCDC2HW8Q+9iF+QVC3sxjDKQYjHQeZ9w=="
+      "version": "10.9.4",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.9.4.tgz",
+      "integrity": "sha512-fCHV45gS+m3hH17zgkgADUSi2RR1Vht6wOZ0jyHP8rjiQra9f+mIcgwPQHllmDocYOstIEbKlxbFDYlgrTPYqw==",
+      "dev": true
     },
     "@types/sinon": {
       "version": "1.16.36",

--- a/package.json
+++ b/package.json
@@ -17,13 +17,13 @@
   "author": "The Polymer Project Authors",
   "license": "BSD-3-Clause",
   "dependencies": {
-    "@types/node": "^10.5.0",
     "winston": "^3.0.0",
     "winston-transport": "^4.2.0"
   },
   "devDependencies": {
     "@types/chai": "^3.4.35",
     "@types/mocha": "^2.2.39",
+    "@types/node": "^10.9.4",
     "@types/sinon": "^1.16.35",
     "chai": "^3.5.0",
     "mocha": "^3.2.0",


### PR DESCRIPTION
 - [x] CHANGELOG.md has been updated

Original plylog v0.5.0 behavior:
![screen shot 2018-09-12 at 12 05 23 pm](https://user-images.githubusercontent.com/578/45447377-3a9b6180-b684-11e8-8d30-d5f309498351.png)

Current weirdo broken v1.0.0 behavior:
![screen shot 2018-09-12 at 12 07 43 pm](https://user-images.githubusercontent.com/578/45447464-7fbf9380-b684-11e8-9b71-2e13e5a55fd7.png)

This PR gets it to:
![screen shot 2018-09-12 at 2 44 36 pm](https://user-images.githubusercontent.com/578/45454978-72150880-b69a-11e8-9ca2-8e593fe6c04d.png)

Which is close enough to the original for now.