### PR TITLE
Got the output to look like the old plylog 0.5.0 by writing an equivalent prettyify replacement formatter.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,12 @@
       "integrity": "sha1-wRzSgX06QBt7oPWkIPNcVhObHB4=",
       "dev": true
     },
+    "@types/logform": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@types/logform/-/logform-1.2.0.tgz",
+      "integrity": "sha512-E8cLzW+PmqHI//4HLR+ZvE3cyzqVjsncYBx1O14P07oVJj3ezhmiL/azlgkXKLFyCWAeKsPQdjHNg/NEhBF5Ow==",
+      "dev": true
+    },
     "@types/mocha": {
       "version": "2.2.48",
       "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-2.2.48.tgz",
@@ -26,6 +32,12 @@
       "version": "1.16.36",
       "resolved": "https://registry.npmjs.org/@types/sinon/-/sinon-1.16.36.tgz",
       "integrity": "sha1-dLtu15KFl8Gz+xsAkAXpTcbq41c=",
+      "dev": true
+    },
+    "@types/triple-beam": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@types/triple-beam/-/triple-beam-1.3.0.tgz",
+      "integrity": "sha512-tl34wMtk3q+fSdRSJ+N83f47IyXLXPPuLjHm7cmAx0fE2Wml2TZCQV3FmQdSR5J6UEGV3qafG054e0cVVFCqPA==",
       "dev": true
     },
     "assertion-error": {
@@ -118,9 +130,9 @@
       "integrity": "sha1-+IiQMGhcfE/54qVZ9Qd+t2qBb5Y="
     },
     "colors": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/colors/-/colors-1.3.1.tgz",
-      "integrity": "sha512-jg/vxRmv430jixZrC+La5kMbUWqIg32/JsYNZb94+JEmzceYbWKTsv1OuTp+7EaqiaWRR2tPcykibwCRgclIsw=="
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/colors/-/colors-1.3.2.tgz",
+      "integrity": "sha512-rhP0JSBGYvpcNQj4s5AdShMeE5ahMop96cTeDl/v9qQQm2fYClE2QXZRi8wLzc+GmXSxdIqqbOIAhyObEXDbfQ=="
     },
     "colorspace": {
       "version": "1.1.1",

--- a/package.json
+++ b/package.json
@@ -17,18 +17,22 @@
   "author": "The Polymer Project Authors",
   "license": "BSD-3-Clause",
   "dependencies": {
+    "logform": "^1.9.1",
     "winston": "^3.0.0",
     "winston-transport": "^4.2.0"
   },
   "devDependencies": {
     "@types/chai": "^3.4.35",
+    "@types/logform": "^1.2.0",
     "@types/mocha": "^2.2.39",
     "@types/node": "^10.9.4",
     "@types/sinon": "^1.16.35",
+    "@types/triple-beam": "^1.3.0",
     "chai": "^3.5.0",
     "mocha": "^3.2.0",
     "sinon": "^1.17.4",
     "source-map-support": "^0.5.9",
+    "triple-beam": "^1.2.0",
     "typescript": "^2.2.1"
   }
 }


### PR DESCRIPTION
Plylog 0.5.0:
![screen shot 2018-09-12 at 12 05 23 pm](https://user-images.githubusercontent.com/578/45508568-fffbfc80-b749-11e8-83ac-5932b291deef.png)

Fixed new:
![screen shot 2018-09-13 at 11 33 47 am](https://user-images.githubusercontent.com/578/45508589-0c805500-b74a-11e8-9a7e-745ff3cae192.png)
