### PR TITLE
Prepare release of plylog 1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,15 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 <!--## Unreleased-->
 
-* Fixed output to colorize the loglevel and use simple non-json output for string messages.
-
 <!--
   New PRs should document their changes here, uncommenting the Unreleased
   heading as necessary.
 -->
+
+## [1.1.0] - 2018-09-14
+
+* Fixed output to colorize the loglevel and use simple non-json output for string messages.
+* Added a `colorize` boolean option to logger constructor to enable turning colors off (on by default).
 
 ## [1.0.0] - 2018-08-21
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "plylog",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "A logger for the Polymer CLI toolchain",
   "main": "index.js",
   "typings": "index.d.ts",


### PR DESCRIPTION
 - [x] CHANGELOG.md has been updated

* Fixed output to colorize the loglevel and use simple non-json output for string messages.
* Added a `colorize` boolean option to logger constructor to enable turning colors off (on by default).